### PR TITLE
Move jupyter notebook installation to envdlib

### DIFF
--- a/src/monitoring.envd
+++ b/src/monitoring.envd
@@ -1,8 +1,5 @@
 def tensorboard(
-    envd_port=6006,
-    envd_dir="/home/envd/logs",
-    host_port=0,
-    host_dir="/tmp",
+    envd_port=6006, envd_dir="/home/envd/logs", host_port=0, host_dir="/tmp"
 ):
     """Configure TensorBoard.
 
@@ -27,7 +24,7 @@ def tensorboard(
                 str(envd_port),
                 "--host",
                 "0.0.0.0",
-            ],
+            ]
         ]
     )
     runtime.expose(envd_port=envd_port, host_port=host_port, service="tensorboard")

--- a/src/notebook.envd
+++ b/src/notebook.envd
@@ -24,3 +24,32 @@ def jupyter_lab(envd_port=8888, host_port=0, token="''"):
             ]
         ]
     )
+
+def jupyter_notebook(envd_port=8888, host_port=0, token="''"):
+    """Configure Jupyter Notebook.
+    Args:
+        envd_port (Optional[int]): port used by envd container (default=8888)
+        host_port (Optional[int]): port used by host, if not specified or equals to 0,
+            envd will randomly choose a free port
+        token (Optional[str]): access token
+    """
+    install.python_packages(["notebook"])
+    runtime.expose(envd_port=envd_port, host_port=host_port, service="jupyter-notebook")
+    runtime.daemon(
+        commands=[
+            [
+                "jupyter",
+                "notebook",
+                "--ip",
+                "0.0.0.0",
+                "--no-browser",
+                "--port",
+                str(envd_port),
+                "--allow-root",
+                "-y",
+                "--NotebookApp.token",
+                token,
+            ]
+        ]
+    )
+

--- a/src/notebook.envd
+++ b/src/notebook.envd
@@ -25,6 +25,7 @@ def jupyter_lab(envd_port=8888, host_port=0, token="''"):
         ]
     )
 
+
 def jupyter_notebook(envd_port=8888, host_port=0, token="''"):
     """Configure Jupyter Notebook.
     Args:
@@ -52,4 +53,3 @@ def jupyter_notebook(envd_port=8888, host_port=0, token="''"):
             ]
         ]
     )
-


### PR DESCRIPTION
As suggested in the [feat: support serving #1228](https://github.com/tensorchord/envd/pull/1228) 

- [x] `config.jupyter()` move to envdlib (Done)

To test this PR:
```python
envdlib = include("https://github.com/tensorchord/envdlib")
def build():
    base(os="ubuntu20.04", language="python3")
    envdlib.jupyter_notebook(9999, 9999) #Or any port mapping you want